### PR TITLE
Added support for the second generation - Shelly "plus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ total 24239
 
 If you get an error, check your environment variables and make sure they're correct, and make sure the Docker container (and the host it's on) can access your Shelly Plug over HTTP!
 
+#### Optional environment variables
+If you have a second generation Shelly (i.e. a relay with a "plus" in the name) you will need to set `SHELLY_GENERATION=2`. For the first generation (non "plus") you can set that to 1 or simply leave it unset.
+
+If you have a relay with multiple switches, such as a PM2, then you can use the `SHELLY_SWITCH_ID` variable to choose which one you want to poll (i.e. `SHELLY_SWITCH_ID=1`). Count starts from 0, all single switch relays only have a switch with id 0.
+
 ## License
 
 MIT.

--- a/metrics
+++ b/metrics
@@ -6,47 +6,31 @@
 
 # Environment variables.
 $hostname = getenv('SHELLY_HOSTNAME');
-$username = getenv('SHELLY_HTTP_USERNAME');
-$password = getenv('SHELLY_HTTP_PASSWORD');
 
-$url = 'http://' . $hostname . '/meter/0';
+# For shelly "plus" branded relays, set this to "2", otherwise, specify "1" (or don't specify at all)
+$generation = getenv('SHELLY_GENERATION');
 
-$curl = curl_init();
+# Some shelly relays have multiple switches (such as the 2PM), this allows you to select which one you want
+# This can be left on the default of "0" for any relays that only have a single switch (such as the shelly plug or shelly 1PM)
+$switch_id = getenv('SHELLY_SWITCH_ID');
 
-# Basic HTTP Authentication (if set).
-if (!empty($username) && !empty($password)) {
-  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-  curl_setopt($curl, CURLOPT_USERPWD, "$username:$password");
+if ($generation === false) {
+  $generation = 1;
 }
 
-curl_setopt($curl, CURLOPT_URL, $url);
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-
-# Call the URL with curl.
-$result = curl_exec($curl);
-if (curl_errno($curl)) {
-  $error_message = curl_error($curl);
-}
-curl_close($curl);
-
-# Handle errors.
-if (isset($error_message)) {
-  echo 'Error: ' . $error_message;
-  return;
+if ($switch_id === false) {
+  $switch_id = 0;
 }
 
-# Parse Shelly Plug's JSON payload and return metrics.
-$results = json_decode($result);
+# For simplicity's sake, I've broken up the two different api accesses into different files for my own peace of mind
+switch ($generation) {
+  case 1:
+    require "shellygen1";
+    break;
+
+  case 2:
+    require "shellygen2";
+    break;
+}
 
 ?>
-# HELP power Current real AC power being drawn, in Watts
-# TYPE power gauge
-power <?php print $results->power; ?>
-
-# HELP is_valid Whether power metering self-checks OK
-# TYPE is_valid gauge
-is_valid <?php print $results->is_valid; ?>
-
-# HELP total Total energy consumed by the attached electrical appliance in Watt-minute
-# TYPE total gauge
-total <?php print $results->total; ?>

--- a/shellygen1
+++ b/shellygen1
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This is terrible. But it is simple and works. So it shall be.
+ */
+
+$url = 'http://' . $hostname . '/meter/' . $switch_id;
+
+$curl = curl_init();
+
+# Basic HTTP Authentication (if set).
+if (!empty($username) && !empty($password)) {
+  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+  curl_setopt($curl, CURLOPT_USERPWD, "$username:$password");
+}
+
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+# Call the URL with curl.
+$result = curl_exec($curl);
+if (curl_errno($curl)) {
+  $error_message = curl_error($curl);
+}
+curl_close($curl);
+
+# Handle errors.
+if (isset($error_message)) {
+  echo 'Error: ' . $error_message;
+  return;
+}
+
+# Parse Shelly Plug's JSON payload and return metrics.
+$results = json_decode($result);
+
+?>
+# HELP power Current real AC power being drawn, in Watts
+# TYPE power gauge
+power <?php print $results->power; ?>
+
+# HELP is_valid Whether power metering self-checks OK
+# TYPE is_valid gauge
+is_valid <?php print $results->is_valid; ?>
+
+# HELP total Total energy consumed by the attached electrical appliance in Watt-minute
+# TYPE total gauge
+total <?php print $results->total; ?>

--- a/shellygen2
+++ b/shellygen2
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This is terrible. But it is simple and works. So it shall be.
+ */
+
+$url = "http://$hostname/rpc/Switch.GetStatus?id=$switch_id";
+
+# The username is hardcoded in the second generation, not sure if that'll change in future
+$username = "admin";
+$password = getenv('SHELLY_HTTP_PASSWORD');
+
+$curl = curl_init();
+
+curl_setopt($curl, CURLOPT_URL, $url);
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+if (isset($password)) {
+  curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+  curl_setopt($curl, CURLOPT_USERPWD, "$username:$password");
+}
+
+$result = curl_exec($curl);
+
+if (curl_errno($curl)) {
+  $error_message = curl_error($curl);
+}
+
+curl_close($curl);
+
+# Handle errors.
+if (isset($error_message)) {
+  echo 'Error: ' . $error_message;
+  return;
+}
+
+# Parse Shelly Plug's JSON payload and return metrics.
+$results = json_decode($result);
+
+?>
+# HELP power Current real AC power being drawn, in Watts
+# TYPE power gauge
+power <?php print $results->apower; ?>
+
+# HELP is_valid Whether power metering self-checks OK
+# TYPE is_valid gauge
+is_valid <?php print !isset($results->errors) && empty($results->errors); ?>
+
+# HELP total Total energy consumed by the attached electrical appliance in Watt-minute
+# TYPE total gauge
+total <?php print $results->aenergy->total; ?>


### PR DESCRIPTION
Since the API for the plus devices is different, I've split up the functionality so that the functionality for polling the first generation is in one file, and the second gen in another.

The structure of these files is largely the same, and you still access both of them via the "metrics" entry point.

Key differences:
  - The new generation uses digest authentication rather than basic, and has a hardcoded username
  - The URL has changed, they now use an RPC style API
  - The format of the json you get back is also different (but standardised across all the new generation

I've also added support for relays with multiple switches (i.e. PM2). I'm not able to test it extensively (yet), as all the relays I have are only of the single variety, but I'm fairly confident it should work, as it was only a minor tweak to the script

Also of note:
The new shellys are also able to report temperature and voltage (and current in amps): https://shelly-api-docs.shelly.cloud/gen2/Components/FunctionalComponents/Switch#status - it might be cool to add them to the graphana/prometheus internet-pi monitoring suite (though I'm not familiar at all with either of them and I'm not sure how the output of this script makes its way into graphana (yet!)