### PR TITLE
Updated to return text/plain content type

### DIFF
--- a/metrics
+++ b/metrics
@@ -23,6 +23,7 @@ if ($switch_id === false) {
 }
 
 # For simplicity's sake, I've broken up the two different api accesses into different files for my own peace of mind
+header("Content-Type: text/plain");
 switch ($generation) {
   case 1:
     require "shellygen1";


### PR DESCRIPTION
With the newest Prometheus version (v3) the mime type is actually important now. 
This just adds a header `"Content-Type: text/plain"` to override PHP's default of `text/html`

I tested it on my homelab, and it works fine with Prometheus v3 :tada: 