### PR TITLE
Fix deprecation of curl_close command for php+8

### DIFF
--- a/shellygen1
+++ b/shellygen1
@@ -25,7 +25,9 @@ $result = curl_exec($curl);
 if (curl_errno($curl)) {
   $error_message = curl_error($curl);
 }
-curl_close($curl);
+if (PHP_VERSION_ID < 80000) {
+  curl_close($curl);
+}
 
 # Handle errors.
 if (isset($error_message)) {

--- a/shellygen2
+++ b/shellygen2
@@ -26,7 +26,9 @@ if (curl_errno($curl)) {
   $error_message = curl_error($curl);
 }
 
-curl_close($curl);
+if (PHP_VERSION_ID < 80000) {
+  curl_close($curl);
+}
 
 # Handle errors.
 if (isset($error_message)) {


### PR DESCRIPTION
In version 8.0 PHP has deprecated the command "curl_close" and it no longer has an effect. In version 8.5 and higher running this command outputs a deprecation message. This message conflicts with Prometheus metrics collection.

https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.curl

While it is likely safe to remove the command entirely, I have added the check for backwards compatibility and I have seen other projects handle this change in a similar way.

This resolves issue #13.